### PR TITLE
A minor modification to regex pattern for RA-GRS.

### DIFF
--- a/lib/Net/Azure/StorageClient.pm
+++ b/lib/Net/Azure/StorageClient.pm
@@ -55,7 +55,7 @@ sub sign {
     my $canonicalized_headers = join '', map { lc( $_ ) . ':' .
        $req->header( $_ ) . "\n" } sort grep { /^x-ms/ } keys %{ $req->headers };
     my $account = $req->uri->authority;
-    $account =~ s/^([^.]*).*$/$1/;
+    $account =~ s/^(\w+).*$/$1/;
     my $path = $req->uri->path;
     my $canonicalized_resource = "/${account}${path}";
     $canonicalized_resource .= join '', map { "\n" . lc( $_ ) . ':' .


### PR DESCRIPTION
日本マイクロソフトの佐々木です

今月Windows Azure Storageに追加された(まだプレビューですが)「読み取りアクセス地理冗長 (RA-GRS)」機能というのがあるのですが、これに対応するためにちょっとだけ変更していただきたい点があり、pull request遅らせていただきました。
Gitに不慣れなので、変なことしてたらすみません・・・

RA-GRSは、ストレージアカウントでデフォルトで有効になっている地理冗長(geo-replication)機能の強化で、セカンダリ側に明示的にアクセスできる(ただし読み取り専用)というものです。
BLOBなら通常は、http://account.blob.core.windows.net/がエンドポイントですが、これにhttp://account-secondary.blob.core.windows.net/と"-secondary"を付けることで、レプリカ先を読み取ることができます。

で、このRA-GRSなのですが、REST APIのエンドポイントは"-secondary"付きのURLに変わるのですが、HTTPリクエストのAuthorizationヘッダにつけるアカウント名は、"-secondary"無しの本来のアカウント名が必要です。
そのため、接続先のURLから「最初のピリオドまでを取り出してアカウント名とする」現状のコードの場合、"account-secondary"がアカウント名としてAhtorizationヘッダについてしまい、そのためエラーが返ってきてしまいます。

signメソッドの正規表現をちょっと変えてみました。
よろしくお願いいたします。
